### PR TITLE
chore: ignore local worktrees and OpenCode artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,13 @@ Thumbs.db
 *.swp
 *.swo
 
+# Local worktrees
+/.worktrees/
+
+# Local OpenCode artifacts
+/registered_agents.json
+/task_agent_mapping.json
+
 # Temporary files
 tmp/
 temp/


### PR DESCRIPTION
## What changed
- Ignore local worktree directory and OpenCode-generated local JSON artifacts

## Why
- Prevent accidental commits of local agent/worktree artifacts and keep working tree clean

## Validation
- [x] pnpm exec tsc --noEmit
- [x] pnpm test
- [x] pnpm build

## Linked issues
- N/A